### PR TITLE
ci: add lint-pr-title.yml workflow

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,20 @@
+name: "Lint PR Title"
+
+on:
+    pull_request:
+        types:
+            - opened
+            - reopened
+            - edited
+            - synchronize
+
+jobs:
+    pr-title:
+        name: Lint PR title
+        runs-on: ubuntu-latest
+        steps:
+            - uses: amannn/action-semantic-pull-request@v3
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  validateSingleCommit: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+-   add workflow to verify if pr title follows conventional commits
+
 ## [0.18.4] - 2022-01-24
 
 -   swapped out the PureComponent to functional + memo in the files i came across

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,7 @@ Note: To test different recipes you need to update the value of `authRecipe` in 
 
 1. Before submitting a pull request make sure all tests have passed
 2. Reference the relevant issue or pull request and give a clear description of changes/features added when submitting a pull request
+3. Make sure the PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
 
 ## SuperTokens Community
 


### PR DESCRIPTION
## Summary of change

Added a github action/workflow that will validate if the PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

## Details

If the PR title does not comply, this helpful failure message will appear.

![image](https://user-images.githubusercontent.com/9292261/151164531-82e1a9b6-f41d-4ece-a019-9cefdae1df01.png)

### Step 1 of X to using `standard-version`

This is step one of the transition towards eventually adopting `standard-version` to automate semantic version bumping and changelog updates. But even if `standard-version` is not used, `conventional-commits` is also a nice standard to adopt to make reading git history slightly more pleasant.

Before officially adopting `standard-version` tho, the following should also be true:
* all the other projects should also adopt `conventional-commits` have this workflow (potentially could be solved with a monorepo structure, this makes docker-compose.yml easier too perhaps)
* there should be an equivalent for `standard-version` for other packages in other languages
* there should be a a custom script prepared to monkey patch any other part of the repo that needs version bumping but is not handled by `standard-version`

## Documentation changes

Updated CONTRIBUTING.md to give a heads up about conventional commits

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.